### PR TITLE
Add CHISN module and the cable to L2 is connected.

### DIFF
--- a/src/test/scala/DongJiang/TestTopCHIL2.scala
+++ b/src/test/scala/DongJiang/TestTopCHIL2.scala
@@ -16,6 +16,7 @@ import coupledL2.prefetch._
 import coupledL2.tl2chi._
 import utility.{ChiselDB, FileRegisters, TLLogger, PerfCounterOptionsKey, PerfCounterOptions}
 import coupledL2._
+import CHISN._
 import xs.utils.perf.{DebugOptions, DebugOptionsKey}
 
 class TestTop_CHIL2(numCores: Int = 1, numULAgents: Int = 0, banks: Int = 1)(implicit p: Parameters) extends LazyModule
@@ -149,15 +150,13 @@ class TestTop_CHIL2(numCores: Int = 1, numULAgents: Int = 0, banks: Int = 1)(imp
       l2.module.io.l2_tlb_req <> DontCare
     }
 
-// ----------------------------- Connect IO_SN <-> ARM_SN -------------------------- //
+// ----------------------------- Connect IO_SN <-> CHI_SN -------------------------- //
     val dongjiang = Module(new DongJiang())
     val connecter = Seq.fill(numCores) { Module(new ConnectChil2()) }
-    val io = IO(new Bundle {
-      val snChi = Vec(dongjiang.djparam.nrBank, CHIBundleDownstream(dongjiang.chiParams))
-      val snChiLinkCtrl = Vec(dongjiang.djparam.nrBank, new CHILinkCtrlIO())
-    })
-    dongjiang.io.snMasChi <> io.snChi
-    dongjiang.io.snMasChiLinkCtrl <> io.snChiLinkCtrl
+    val chiSn     = Module(new CHISN())
+
+    dongjiang.io.snMasChi <> chiSn.io.hnChi
+    dongjiang.io.snMasChiLinkCtrl <> chiSn.io.hnLinkCtrl
 
     dontTouch(dongjiang.io)
     dontTouch(l2_nodes(0).module.io_chi)

--- a/src/test/scala/DongJiang/TestTopNHL2.scala
+++ b/src/test/scala/DongJiang/TestTopNHL2.scala
@@ -128,7 +128,7 @@ class TestTop_NHL2(numCores: Int = 1, numULAgents: Int = 0, banks: Int = 1)(impl
 
     l2_nodes.foreach(_.module.io.nodeID := l2NodeID.U)
 
-// ----------------------------- Connect IO_SN <-> ARM_SN -------------------------- //
+// ----------------------------- Connect IO_SN <-> CHI_SN -------------------------- //
     val dongjiang = Module(new DongJiang())
     val chiSn     = Module(new CHISN())
 


### PR DESCRIPTION
# CHISN

## CHISN Interface
Such as RxDat TxDat TxReq RxRsp adopt boundFlitCtrl module, layerLinkCtrl adopts boundLinkCtrl module. But some bugs may occur due to adaptation. 
```
  val snChiTxReq            = Module(new InboundFlitCtrl(gen = new CHIBundleREQ(chiParams), lcrdMax = nodeParam.nrSnTxLcrdMax, nodeParam.aggregateIO))
  val snChiTxDat            = Module(new InboundFlitCtrl(gen = new CHIBundleDAT(chiParams), lcrdMax = nodeParam.nrSnTxLcrdMax, nodeParam.aggregateIO))

  val snChiRxDat            = Module(new OutboundFlitCtrl(gen = new CHIBundleDAT(chiParams), lcrdMax = nodeParam.nrSnRxLcrdMax, nodeParam.aggregateIO))
  val snChiRxRsp            = Module(new OutboundFlitCtrl(gen = new CHIBundleRSP(chiParams), lcrdMax = nodeParam.nrSnRxLcrdMax, nodeParam.aggregateIO))
```

## WriteBuf
This module provides the write request FSM, when receiving the write request flit, update FSM and wait for the data to write, when the data arrvices, update the state machine again, and send the write data and write address to the WrDat module.

## RspGen
Generate response signals to DSUChiRxRsp. 
```
  readReqOrder              := io.reqFlitIn.bits.opcode === REQ.ReadNoSnp      & io.reqFlitIn.fire & io.reqFlitIn.bits.order =/= 0.U
  rspFlit.opcode            := Mux(writeReq, RSP.CompDBIDResp, Mux(readReqOrder, RSP.ReadReceipt, 0.U))
```
When receive a write request, responds CompDBIDResp response flit.
Generate a response signal : ReadReceipt, when a read request is received.

## MemHelper
The DPIC method is adopted is simulate the realization of memory. Pay attention to the location of cpp file in Verilua_dsu

## SnSlice
Cables between modules are connected.

## CHISN
Instantiate the complete CHISN, which adapts to multiple banks.
```
 cmem.zip(snSlices).foreach{case(mem, sn) => mem.rIdx := sn.io.readCmemAddr;  mem.ren := sn.io.readCmemEn;  sn.io.readCmemRsp := mem.rdata}
  cmem.zip(snSlices).foreach{case(mem, sn) => mem.wIdx := sn.io.writeCmemAddr; mem.wen := sn.io.writeCmemEn; mem.wdata := sn.io.writeCmemData; mem.clk := clock}
```

## Bundles:
Defines some of the Bundles required by the module.

## DatGen
Read data from memory and generate data flits to DSUChiRxDat.

## WrDat
Write data to memory.